### PR TITLE
ARMアーキテクチャのMacでもビルドできるようベースイメージを変更

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -400,8 +400,8 @@ A: はい。Docker内でJavaとAlloyが動作するため、ホストにJavaは�
 **Q: Docker Desktopがないと使えませんか?**  
 A: macOSの場合はDocker Desktop推奨。Linux/WSLならDocker Engineでも可能。
 
-**Q: M1/M2 Macで動作しますか?**  
-A: はい。Alpine LinuxベースのイメージはARM64に対応しています。
+**Q: M1/M2/M4 Macで動作しますか?**  
+A: Debianベースのイメージを使用し、対応しています。
 
 **Q: オフライン環境で使えますか?**  
 A: Dockerイメージをビルド済みであれば可能。ビルド時のみインターネット接続が必要。

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -80,6 +80,7 @@ ls .claude/commands/
 
 ```bash
 # templates/ → .specify/templates/
+mkdir -p .specify/templates
 cp -r ${FORMAL_PKG}/templates/* .specify/templates/
 
 # 確認
@@ -95,7 +96,7 @@ ls .specify/templates/ | grep modelcheck
 ```bash
 # docker/ → ./docker/alloy/ (既存のdocker/と衝突しない)
 mkdir -p docker/alloy
-cp -r ${FORMAL_PKG}/docker/* docker/alloy/
+find ${FORMAL_PKG}/docker/ -maxdepth 1 -type f -exec cp {} docker/alloy/ \;
 
 # docker-compose.yaml → ./
 # 注意: 既存のdocker-compose.yamlがある場合はマージが必要

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
 # Alloy AnalyzerのDockerfile
+# Note: Using eclipse-temurin:17-jdk (not alpine) for ARM64 support
+# Alpine variant (17-jdk-alpine) does not support ARM64 architecture
 
-FROM eclipse-temurin:17-jdk-alpine
+FROM eclipse-temurin:17-jdk
 
 # Alloy Analyzerのバージョン
 ARG ALLOY_VERSION=6.2.0
@@ -9,9 +11,12 @@ ARG ALLOY_VERSION=6.2.0
 WORKDIR /alloy
 
 # Alloy Analyzerをダウンロード & jqをインストール
-RUN apk add --no-cache wget jq && \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends wget jq && \
     wget -O alloy.jar "https://github.com/AlloyTools/org.alloytools.alloy/releases/download/v${ALLOY_VERSION}/org.alloytools.alloy.dist.jar" && \
-    apk del wget
+    apt-get purge -y wget && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # 検証スクリプトをコピー
 COPY verify-alloy.sh /usr/local/bin/verify-alloy

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -48,38 +48,28 @@ NC='\033[0m' # No Color
 
 # Show help
 show_help() {
-    cat << EOF
-${GREEN}Alloy Model Checking Tool (Docker version)${NC}
-
-Usage:
-  ./verify.sh <alloy-file> [options]
-
-Arguments:
-  alloy-file       Path to .als file to verify
-                   (e.g., specs/001-purchase/formal/purchase.als)
-
-Options:
-  --timeout N      Timeout in seconds (default: 300)
-  --format FORMAT  Output format: text, xml (default: text)
-  --build          Rebuild Docker image
-  --shell          Start Alloy environment shell
-  --help           Show this help
-
-Note: Scope is specified in the .als file (e.g., "check PropertyName for 5 but 8 Int")
-
-Examples:
-  # Basic verification
-  ./verify.sh specs/001-purchase/formal/purchase.als
-
-  # Specify timeout
-  ./verify.sh specs/001-purchase/formal/purchase.als --timeout 600
-
-  # Rebuild image and verify
-  ./verify.sh specs/001-purchase/formal/purchase.als --build
-
-  # Start debug shell
-  ./verify.sh --shell
-EOF
+    printf "${GREEN}Alloy Model Checking Tool (Docker version)${NC}\n\n"
+    printf "Usage:\n"
+    printf "  ./verify.sh <alloy-file> [options]\n\n"
+    printf "Arguments:\n"
+    printf "  alloy-file       Path to .als file to verify\n"
+    printf "                   (e.g., specs/001-purchase/formal/purchase.als)\n\n"
+    printf "Options:\n"
+    printf "  --timeout N      Timeout in seconds (default: 300)\n"
+    printf "  --format FORMAT  Output format: text, xml (default: text)\n"
+    printf "  --build          Rebuild Docker image\n"
+    printf "  --shell          Start Alloy environment shell\n"
+    printf "  --help           Show this help\n\n"
+    printf "Note: Scope is specified in the .als file (e.g., \"check PropertyName for 5 but 8 Int\")\n\n"
+    printf "Examples:\n"
+    printf "  # Basic verification\n"
+    printf "  ./verify.sh specs/001-purchase/formal/purchase.als\n\n"
+    printf "  # Specify timeout\n"
+    printf "  ./verify.sh specs/001-purchase/formal/purchase.als --timeout 600\n\n"
+    printf "  # Rebuild image and verify\n"
+    printf "  ./verify.sh specs/001-purchase/formal/purchase.als --build\n\n"
+    printf "  # Start debug shell\n"
+    printf "  ./verify.sh --shell\n"
 }
 
 # Build Docker image


### PR DESCRIPTION


close https://github.com/shinjiroy/model-checking-on-sdd/issues/23

ついでにColorが効いてなかったのでcatからsprintfに変更